### PR TITLE
Added logic to block the current thread until we assert when we are l ogging an error so that the stack trace is maintained

### DIFF
--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -200,19 +200,18 @@ open class Logger {
             function: function,
             date: date
         )
-
-        let logGroup = DispatchGroup()
-        logGroup.enter()
-        queue.async { // Go to the logging thread so that execution can continue smoothly
-            Swift.print(result, separator: "", terminator: "")
-            self.appedStringToLog(result)
-            logGroup.leave()
-        }
         
-        if level == .error { // If we are logging an error, block the current thread and wait until logging is complete so that we can maintian the stacktrace
-            logGroup.wait()
-            assert(false, result)
-        }
+        #if DEBUG
+        log(result: result)
+        assert(level != .error, result)
+        #else
+        queue.async { self.log(result: result) }
+        #endif
+    }
+    
+    private func log(result: String) {
+        Swift.print(result, separator: "", terminator: "")
+        appedStringToLog(result)
     }
     
     /**

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -201,10 +201,17 @@ open class Logger {
             date: date
         )
 
-        queue.async {
+        let logGroup = DispatchGroup()
+        logGroup.enter()
+        queue.async { // Go to the logging thread so that execution can continue smoothly
             Swift.print(result, separator: "", terminator: "")
             self.appedStringToLog(result)
-            assert(level != .error, result)
+            logGroup.leave()
+        }
+        
+        if level == .error { // If we are logging an error, block the current thread and wait until logging is complete so that we can maintian the stacktrace
+            logGroup.wait()
+            assert(false, result)
         }
     }
     


### PR DESCRIPTION
There is currently an issue in this PR where if we are in a production environment where `assert` has no effect, this will still block the main thread even when logging an error even though it doesn't have to